### PR TITLE
30 iteritems warning

### DIFF
--- a/docs/source/user_guide/ied.rst
+++ b/docs/source/user_guide/ied.rst
@@ -105,7 +105,7 @@ The following example demonstrates how the ``IED`` class could be used to edit t
         hydrograph = qtbdy_unit.data # Get hydrograph from qtbdy unit
         peak_flow = hydrograph.max() # Get peak flow value
         peak_flow_idx = hydrograph.loc[hydrograph == peak_flow].index # Get index of peak flow
-        for time, flow in hydrograph.iteritems(): # Iterate through hydrograph series
+        for time, flow in hydrograph.items(): # Iterate through hydrograph series
             if time > peak_flow_idx: # For only flows after peak flow i.e. falling limb
                 if flow < peak_flow * 0.3: # If the flow is less than 30% of the peak
                     hydrograph.loc[time] = peak_flow * 0.3 # Maintain minimum flow of 30% of peak for remainder of hydrograph

--- a/floodmodeller_api/units/boundaries.py
+++ b/floodmodeller_api/units/boundaries.py
@@ -135,9 +135,9 @@ class QTBDY(Unit):
         )
 
         if self.timeunit == "DATES":
-            qtbdy_data = [join_10_char(q) + t for t, q in self.data.iteritems()]
+            qtbdy_data = [join_10_char(q) + t for t, q in self.data.items()]
         else:
-            qtbdy_data = [join_10_char(q, t) for t, q in self.data.iteritems()]
+            qtbdy_data = [join_10_char(q, t) for t, q in self.data.items()]
         qtbdy_block = [header, name, qtbdy_params]
         qtbdy_block.extend(qtbdy_data)
 
@@ -223,9 +223,9 @@ class HTBDY(Unit):
             self.interpmethod,
         )
         if self.timeunit == "DATES":
-            htbdy_data = [join_10_char(h) + t for t, h in self.data.iteritems()]
+            htbdy_data = [join_10_char(h) + t for t, h in self.data.items()]
         else:
-            htbdy_data = [join_10_char(h, t) for t, h in self.data.iteritems()]
+            htbdy_data = [join_10_char(h, t) for t, h in self.data.items()]
         htbdy_block = [header, name, htbdy_params]
         htbdy_block.extend(htbdy_data)
 
@@ -286,7 +286,7 @@ class QHBDY(Unit):
         self.nrows = len(self.data)
 
         qhbdy_params = join_10_char(self.nrows, 0.000, self.interpmethod)
-        qhbdy_data = [f"{q:>10.3f}{h:>10.3f}" for h, q in self.data.iteritems()]
+        qhbdy_data = [f"{q:>10.3f}{h:>10.3f}" for h, q in self.data.items()]
         qhbdy_block = [header, name, qhbdy_params]
         qhbdy_block.extend(qhbdy_data)
 

--- a/floodmodeller_api/units/losses.py
+++ b/floodmodeller_api/units/losses.py
@@ -268,10 +268,10 @@ class BLOCKAGE(Unit):
 
         if self.timeunit == "DATES":
             blockage_data = [
-                f"{t:<20}{join_10_char(b)}" for t, b in self.data.iteritems()
+                f"{t:<20}{join_10_char(b)}" for t, b in self.data.items()
             ]
         else:
-            blockage_data = [join_10_char(t, b) for t, b in self.data.iteritems()]
+            blockage_data = [join_10_char(t, b) for t, b in self.data.items()]
 
         blockage_block.extend(blockage_data)
 

--- a/floodmodeller_api/units/structures.py
+++ b/floodmodeller_api/units/structures.py
@@ -15,7 +15,6 @@ address: Jacobs UK Limited, Flood Modeller, Cottons Centre, Cottons Lane, London
 """
 
 
-from msilib.schema import Class
 import pandas as pd
 
 from ._base import Unit

--- a/floodmodeller_api/units/structures.py
+++ b/floodmodeller_api/units/structures.py
@@ -751,7 +751,7 @@ class SLUICE(Unit):
                 block.append(f"GATE {n}")
                 nrows = len(gate)
                 block.append(f"{nrows:>10}")
-                gate_data = [f"{join_10_char(t, o)}" for t, o in gate.iteritems()]
+                gate_data = [f"{join_10_char(t, o)}" for t, o in gate.items()]
                 block.extend(gate_data)
                 n += 1
 
@@ -791,7 +791,7 @@ class SLUICE(Unit):
             block.append(join_10_char(len(self.time_rule_data)))
             time_rule_data = [
                 f"{join_10_char(t)}{o_r:<10}"
-                for t, o_r in self.time_rule_data.iteritems()
+                for t, o_r in self.time_rule_data.items()
             ]
             block.extend(time_rule_data)
 

--- a/sample_scripts/alter_qtbdy_hydrograph.py
+++ b/sample_scripts/alter_qtbdy_hydrograph.py
@@ -23,7 +23,7 @@ def update_hydrograph (qtbdy_unit):
     hydrograph = qtbdy_unit.data # Get hydrograph from qtbdy unit
     peak_flow = hydrograph.max() # Get peak flow value
     peak_flow_idx = hydrograph.loc[hydrograph == peak_flow].index # Get index of peak flow
-    for time, flow in hydrograph.iteritems(): # Iterate through hydrograph series
+    for time, flow in hydrograph.items(): # Iterate through hydrograph series
         if time > peak_flow_idx: # For only flows after peak flow i.e. falling limb
             if flow < peak_flow * 0.5: # If the flow is less than 50% of the peak
                 hydrograph.loc[time] = peak_flow * 0.5 # Maintain minimum flow of 50% of peak for remainder of hydrograph

--- a/test/test_ied.py
+++ b/test/test_ied.py
@@ -7,9 +7,24 @@ from floodmodeller_api import IED
 def ied_fp(test_workspace):
     return os.path.join(test_workspace, "network.ied")
 
+
 def test_open_ied_does_not_change_file(ied_fp):
     """IED: Test str representation equal to ied file with no changes"""
     with open(ied_fp, "r") as ied_file:
         data_before = ied_file.read()
     ied = IED(ied_fp)
     assert ied._write() == data_before
+
+
+def test_qtbdy_write_works(ied_fp):
+    ied = IED(ied_fp)
+    cs26_expected = [
+        "QTBDY ",
+        "CS26",
+        "         4     0.000     0.000   seconds  NOEXTEND    LINEAR     0.000     0.000  OVERRIDE",
+        "     1.000     0.000",
+        "     1.000 46800.000",
+        "     0.000 47160.000",
+        "     0.000 1.000e+09",
+    ]
+    assert ied.boundaries["CS26"]._write() == cs26_expected


### PR DESCRIPTION
Simple PR to replace `.iteritems()` with `.items()` (#30) and remove unused `msilib` dependency (#42). 