### PR TITLE
Xml2d documentation (#48)

### DIFF
--- a/docs/source/user_guide/xml2d.rst
+++ b/docs/source/user_guide/xml2d.rst
@@ -131,6 +131,66 @@ valid.
 An XML2D instance can be updated in place and saved in the same way as for all other files
 supported by the API using the ``.update()`` and ``.save()`` methods respectively.
 
+Add and remove functionality
+--------------------------------
+We can update the xml file directly from the API by adding and removing properties. 
+Imagine that we start with an almost blank xml file that passes the validation, 
+
+.. code:: python
+
+    model = XML2D()
+
+First we can change a variable that already exists. For instance we can change the value of 
+the topography,
+
+.. code:: python
+
+    model.domains[domain_name]["topography"] = 'path/to/my_topography.asc'
+
+We can edit any value that is already in the xml tree in the same way by overwritting it, another 
+example is we can change the end time of the computation,
+
+.. code:: python
+
+    model.domains[domain_name]["time"]["total"] = 1.00
+
+We can also add information to a key that does not exist yet, such as roughness. We first begin 
+by defining an empty list and then populate it with a dictionary, we can keep appending so we have 
+as many dictionaries in a list as we want,
+
+.. code:: python
+    
+    model.domains[domain_name]["roughness"] = [] # created an empty list we can append dictionaries to
+    model.domains[domain_name]["roughness"].append(
+        {'type': 'file', 'law': 'manning', 'value': 'path/to/my_roughness_file.shp'}
+    )
+    # adding second roughness file.
+    model.domains[domain_name]["roughness"].append(
+        {'type': 'file', 'law': 'manning', 'value': 'path/to/my_second_roughness_file.shp'}
+    )
+
+If we wanted to edit one of the roughness values then we would need to use the list indexing, to 
+change the file for the first roughness,
+
+.. code:: python
+
+    model.domains[domain_name]["roughness"][0]["value"] = 'path/to/my_new_roughness_file.shp'
+
+To remove values or keys from the xml file we can use ``del ...`` followed by the part you want to 
+remove. If we want to remove the second roughness entry for instance then,
+
+.. code:: python
+
+    del model.domains[domain_name]["roughness"][1]
+
+Further, we can remove all information relating to the key roughness,
+
+.. code:: python
+
+    del model.domains[domain_name]["roughness"]
+
+
+
 Reference
 --------------
 .. autoclass:: floodmodeller_api.XML2D

--- a/floodmodeller_api/xml2d.py
+++ b/floodmodeller_api/xml2d.py
@@ -351,7 +351,7 @@ class XML2D(FMFile):
                 try:
                     self._recursive_remove_data_xml(new_dict[elem_key][list_idx], elem)
                     list_idx += 1
-                except IndexError:
+                except (IndexError, KeyError):
                     parent.remove(elem)
 
             elif elem_key in new_dict:


### PR DESCRIPTION
* begins extending simulate. Adds package subprocess

* changed engines specific for 2d engines

* added remaining functions, similar to logfiles need to be added

* edits comments

* fixes typo in printed message

* attempts to replicate the .execute as in ief file. Currently missing all log information

* Create xml2d_testing_notebook.ipynb

* adding print to say engine found/executed.

* adds functions for log file including copying functons from ief, begining to adapt to LF2 type. Multiple flags in comments to signpost change for removing variable steady/unsteady

* makes minor edits and begins progressbar function

* updates testing notebook

* attempted to return exitcode

* corrects handelling of exitcode and interpretation

* added dictionary of some error codes

* isolates the dictionary to find scheme used

* adds dictionary call to exitcode message

* imported dictionary for error messages to init

* removed RunType variable and unused functions

* corrects handling of exitcode

* makes minor edits to notebook, exitcode displayed successfully!

* added updating of progress bar from ief class

* adds tdqm package for the loading bar

* adds check for switching to FAST solver and removed comments

* runs .execute() for test case

* adds comments for future work

* attempts to add new attribute to dictionary

* adds package xml to attempt to add attribute to xml file

* tries using lxml package instead of xml package

* adapts so new attributes can be added but fails due to incorrect order

* adds comment for work to do tomorrow

* changes path to schema to removed order in structure requirement

* updates new new of notebook, no change  to code

* adds routine for extracting all possible elements in a branch. Also has added comments for future work and a try and except just incase the user hasn't added new elements.

* adds various work arounds for adding branch further up tree

* adds ability to ALMOST add new subelement. Try/except is to get around trying to take the length of a float, have work around for that now. Issue is currently with line 268, trying to update with orig_dict, out of index!

* appends extra entry to orig_dict, hits error

* adds beginning structure for reordering function

* adapts code so it uses pre-existing variables

* adds pseudocode from Joe Pierce for recursive idea

* updates reordering function. Still not working

* adapts subelement key so correct path is added

* JP review of add and sort elems

* begins adding capability to remove elements/branches

* adds more to removing routine, untested

* begins updating removing data in correct structure

* adds condition to continue recursion or remove element

* adds in pseudocode for removing method

* fix remove element handling

* xml2d.simulate method review

* begins initial part of guide as a test

* makes minor edit

* adds examples to documentation

* reformats so hopefully equations show

* adds title

* corrects typos and includes extra example

* minor typo corrected

* extend except clause to remove branch eg roughness

* adds functions to test add/remove functionality

* removing unneeded notebook

---------