### PR TITLE
Added versioning to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pandas
-tqdm
-lxml
-pytest
-pytest-cov
+pandas==2.0.2
+tqdm==4.65.0
+lxml==4.9.2
+pytest==7.3.1
+pytest-cov==4.1.0

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(
     long_description=readme_txt,
     long_description_content_type="text/markdown",
     include_package_data=True,
-    install_requires=["pandas", "lxml", "tqdm", "pytest"],
+    install_requires=["pandas==2.0.2", "lxml==4.9.2", "tqdm==4.65.0", "pytest==7.3.1"],
 )

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(
     long_description=readme_txt,
     long_description_content_type="text/markdown",
     include_package_data=True,
-    install_requires=["pandas==2.0.2", "lxml==4.9.2", "tqdm==4.65.0", "pytest==7.3.1"],
+    install_requires=["pandas>1,<3", "lxml==4.*", "tqdm==4.*", "pytest>4,<8"],
 )


### PR DESCRIPTION
## Summary

Adding versioning to dependencies mitigates the risk of breaking changes introduced by a major update of third-party code.

I deduced the versions via the following:
- `pip install -r requirements.txt`
- Confirm unit tests pass
- Add the versions of each dependency downloaded by `pip`

## Comments

One alternative you could consider would be be to use more generic versions (e.g., I *think* `pandas==2` would allow you to use the latest version of `pandas` so long as a major change to `v3.0.0` does not occur). However, I usually prefer to specify the exact version, and explicitly update when/if you wanted the latest changes from a dependency.
