### PR TITLE
fix revision comment and CRLF windows line endings

### DIFF
--- a/floodmodeller_api/_base.py
+++ b/floodmodeller_api/_base.py
@@ -90,7 +90,7 @@ class FMFile(Jsonable):
             raise UserWarning(msg)
 
         string = self._write()
-        with open(self._filepath, "w", encoding=self.ENCODING) as _file:
+        with open(self._filepath, "w", encoding=self.ENCODING, newline="\r\n") as _file:
             _file.write(string)
         logging.info("%s File Updated!", self._filepath)
 
@@ -104,7 +104,7 @@ class FMFile(Jsonable):
             Path.mkdir(filepath.parent)
 
         string = self._write()
-        with open(filepath, "w", encoding=self.ENCODING) as _file:
+        with open(filepath, "w", encoding=self.ENCODING, newline="\r\n") as _file:
             _file.write(string)
         self._filepath = filepath  # Updates the filepath attribute to the given path
 

--- a/floodmodeller_api/dat.py
+++ b/floodmodeller_api/dat.py
@@ -88,7 +88,7 @@ class DAT(FMFile):
         if self._gxy_data is not None:
             gxy_string = self._gxy_data
             new_gxy_path = filepath.with_suffix(".gxy")
-            with open(new_gxy_path, "w") as gxy_file:
+            with open(new_gxy_path, "w", encoding=self.ENCODING, newline="\r\n") as gxy_file:
                 gxy_file.write(gxy_string)
             self._gxy_filepath = new_gxy_path
 

--- a/floodmodeller_api/test/test_unit.py
+++ b/floodmodeller_api/test/test_unit.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from floodmodeller_api.units._base import Unit  # update this import path to match your repo
+
+
+class DummyUnit(Unit):
+    def __init__(self, unit_value: str):
+        self._unit = unit_value
+
+
+@pytest.mark.parametrize(
+    ("unit", "header", "expected_revision", "expected_comment"),
+    [
+        ("RESERVOIR", "RESERVOIR 45678 This is a comment", None, "45678 This is a comment"),
+        ("RESERVOIR", "RESERVOIR #revision#1 Mr Comment123", 1, "Mr Comment123"),
+        ("LATERAL", "LATERAL #revision#1", 1, ""),
+    ],
+)
+def test_get_revision_and_comment(
+    unit: str,
+    header: str,
+    expected_revision: int | None,
+    expected_comment: str,
+):
+    dummy_unit = DummyUnit(unit)
+    revision, comment = dummy_unit._get_revision_and_comment(header)
+    assert revision == expected_revision
+    assert comment == expected_comment

--- a/floodmodeller_api/test/test_unit.py
+++ b/floodmodeller_api/test/test_unit.py
@@ -28,3 +28,28 @@ def test_get_revision_and_comment(
     revision, comment = dummy_unit._get_revision_and_comment(header)
     assert revision == expected_revision
     assert comment == expected_comment
+
+
+@pytest.mark.parametrize(
+    ("unit", "header", "remove_revision", "expected_result"),
+    [
+        ("RESERVOIR", "RESERVOIR 45678 This is a comment", True, "45678 This is a comment"),
+        ("RESERVOIR", "RESERVOIR #revision#1 Mr Comment123", True, "Mr Comment123"),
+        (
+            "LATERAL",
+            "LATERAL #revision#1 another #revision#1 tag",
+            True,
+            "another #revision#1 tag",
+        ),
+        (
+            "LATERAL",
+            "LATERAL #revision#1 another #revision#1 tag",
+            False,
+            "#revision#1 another #revision#1 tag",
+        ),
+    ],
+)
+def test_remove_unit_name(unit: str, header: str, remove_revision: bool, expected_result: str):
+    dummy_unit = DummyUnit(unit)
+    result = dummy_unit._remove_unit_name(header, remove_revision=remove_revision)
+    assert result == expected_result

--- a/sample_code/uplift_floodplain_mannings.py
+++ b/sample_code/uplift_floodplain_mannings.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from floodmodeller_api import DAT
+from floodmodeller_api.units import FLOODPLAIN, RIVER
+
+
+def uplift_floodplain_and_river_mannings(dat, uplift_factor):
+    for unit in dat._all_units:
+        if isinstance(unit, (FLOODPLAIN, RIVER)):
+            unit.data["Mannings n"] *= uplift_factor
+
+
+if __name__ == "__main__":
+
+    dat_filepath = Path("<...>.dat")
+    for uplift_factor, suffix in [(0.8, "_Nmin20"), (1.2, "_Nplus20")]:
+        dat = DAT(dat_filepath)
+        uplift_floodplain_and_river_mannings(dat, uplift_factor)
+        new_dat_filepath = dat_filepath.with_stem(dat_filepath.stem + suffix)
+        dat.save(new_dat_filepath)


### PR DESCRIPTION
Things done:
- Updated the Unit._get_revision_and_comment() method to use a more robust regex match
- Also updated Unit._remove_unit_name to be more robust in removing the revision with regex (this isn't actually used now with the remove revision flag but it may be in future)
- added tests for both the above
- Added newline="\r\n" to the FMFile writing to resolve windows trying to read text file without CRLF line endings