### PR TITLE
191 dictionary type not suitiable for iefeventdata due to unique keys

### DIFF
--- a/docs/source/user_guide/ief.rst
+++ b/docs/source/user_guide/ief.rst
@@ -95,6 +95,12 @@ When editing event data attibutes, they can simply be edited in the same way as 
 For example, deleting keys using ``del``, adding new keys and editing existing ones.
 
 .. warning::
+    Due to the ``.eventdata`` attribute using a dictionary, reading an IEF file with duplicate event titles 
+    (incluidng blank event titles) will result in a dictionary where the duplicated events are suffixed with
+    '_<1>', '_<2>' etc, where the first instance is left unchanged. Upon writing to file (via ``ief.save()``,
+     ``ief._write()`` etc.), any added suffixes are removed (in accordance to the regex pattern ``_<\d>$``)
+
+.. warning::
     The ``.eventdata`` attribute has been changed to use a dictionary as of version 0.4.1 of 
     the API. Previously in v0.4.0 ``.eventdata`` would return a list instead, without support
     for reading/editing the event data titles. This introduces a change which is incompatible 

--- a/docs/source/user_guide/ief.rst
+++ b/docs/source/user_guide/ief.rst
@@ -96,9 +96,9 @@ For example, deleting keys using ``del``, adding new keys and editing existing o
 
 .. warning::
     Due to the ``.eventdata`` attribute using a dictionary, reading an IEF file with duplicate event titles 
-    (incluidng blank event titles) will result in a dictionary where the duplicated events are suffixed with
-    '_<1>', '_<2>' etc, where the first instance is left unchanged. Upon writing to file (via ``ief.save()``, 
-    ``ief._write()`` etc.), any added suffixes are removed (in accordance to the regex pattern ``_<\d>$``)
+    (including blank event titles) will result in a dictionary where the duplicated events are suffixed with
+    '<0>', '<1>' etc, where the first instance is left unchanged. Upon writing to file (via ``ief.save()``, 
+    ``ief._write()`` etc.), any added suffixes are removed (in accordance to the regex pattern ``<\d>$``)
 
 .. warning::
     The ``.eventdata`` attribute has been changed to use a dictionary as of version 0.4.1 of 

--- a/docs/source/user_guide/ief.rst
+++ b/docs/source/user_guide/ief.rst
@@ -97,8 +97,8 @@ For example, deleting keys using ``del``, adding new keys and editing existing o
 .. warning::
     Due to the ``.eventdata`` attribute using a dictionary, reading an IEF file with duplicate event titles 
     (incluidng blank event titles) will result in a dictionary where the duplicated events are suffixed with
-    '_<1>', '_<2>' etc, where the first instance is left unchanged. Upon writing to file (via ``ief.save()``,
-     ``ief._write()`` etc.), any added suffixes are removed (in accordance to the regex pattern ``_<\d>$``)
+    '_<1>', '_<2>' etc, where the first instance is left unchanged. Upon writing to file (via ``ief.save()``, 
+    ``ief._write()`` etc.), any added suffixes are removed (in accordance to the regex pattern ``_<\d>$``)
 
 .. warning::
     The ``.eventdata`` attribute has been changed to use a dictionary as of version 0.4.1 of 

--- a/floodmodeller_api/ief.py
+++ b/floodmodeller_api/ief.py
@@ -100,7 +100,7 @@ class IEF(FMFile):
         self.EventData: dict[str, str] = {}
         self.flowtimeprofiles: list[FlowTimeProfile] = []
 
-        self._raw_eventdata = []
+        raw_eventdata = []
         for line in raw_data:
             # Handle any comments here (prefixed with ;)
             if line.lstrip().startswith(";"):
@@ -119,7 +119,7 @@ class IEF(FMFile):
                             event_data_title = value
                     else:
                         event_data_title = prev_comment
-                    self._raw_eventdata.append((event_data_title, value))
+                    raw_eventdata.append((event_data_title, value))
                     self._ief_properties.append("EventData")
 
                 elif prop.upper().startswith("FLOWTIMEPROFILE"):
@@ -137,7 +137,7 @@ class IEF(FMFile):
                 self._ief_properties.append(line)
                 prev_comment = None
 
-        self._eventdata_read_helper()
+        self._eventdata_read_helper(raw_eventdata)
         self._check_formatting(raw_data)
         self._update_ief_properties()  # call this here to ensure ief properties is correct
 
@@ -338,9 +338,9 @@ class IEF(FMFile):
                     if removed == to_remove:
                         break
 
-    def _eventdata_read_helper(self) -> None:
+    def _eventdata_read_helper(self, raw_eventdata) -> None:
         # now we deal with the event data, and convert it into the dict-based .eventdata
-        for title, ied_path in self._raw_eventdata:
+        for title, ied_path in raw_eventdata:
             n = 0
             new_title = title
             while True:

--- a/floodmodeller_api/ief.py
+++ b/floodmodeller_api/ief.py
@@ -37,8 +37,6 @@ from .to_from_json import Jsonable
 from .util import handle_exception, is_windows
 from .zz import ZZN
 
-#TODO change _ from the end of the write regex
-#TODO make the counting start from 0, and append to first blank event
 
 def try_converting(value: str) -> str | int | float:
     """Attempt to parse value as float or int if valid, else return the original string"""
@@ -344,10 +342,8 @@ class IEF(FMFile):
         # now we deal with the event data, and convert it into the dict-based .eventdata
         for title, ied_path in raw_eventdata:
             n = -1
-            if title == "":
-                new_title = "<0>"
-            else:
-                new_title = title
+
+            new_title = "<0>" if title == "" else title
 
             while True:
                 if new_title not in self.eventdata:

--- a/floodmodeller_api/ief.py
+++ b/floodmodeller_api/ief.py
@@ -37,6 +37,8 @@ from .to_from_json import Jsonable
 from .util import handle_exception, is_windows
 from .zz import ZZN
 
+#TODO change _ from the end of the write regex
+#TODO make the counting start from 0, and append to first blank event
 
 def try_converting(value: str) -> str | int | float:
     """Attempt to parse value as float or int if valid, else return the original string"""
@@ -185,7 +187,7 @@ class IEF(FMFile):
                     if idx == event_index:
                         # we enter this block if we're ready to write the event data
                         title = re.sub(
-                            r"_<\d>$",
+                            r"<\d>$",
                             "",
                             key,
                         )  # scrub off any extra bits we've added as part of the make-unique bit of reading.
@@ -341,14 +343,18 @@ class IEF(FMFile):
     def _eventdata_read_helper(self, raw_eventdata) -> None:
         # now we deal with the event data, and convert it into the dict-based .eventdata
         for title, ied_path in raw_eventdata:
-            n = 0
-            new_title = title
+            n = -1
+            if title == "":
+                new_title = "<0>"
+            else:
+                new_title = title
+
             while True:
                 if new_title not in self.eventdata:
                     self.eventdata[new_title] = ied_path
                     break
                 n += 1
-                new_title = title + f"_<{n}>"
+                new_title = title + f"<{n}>"
 
     def _update_flowtimeprofile_info(self) -> None:
         """Update the flowtimeprofile data stored in ief properties"""

--- a/floodmodeller_api/ief.py
+++ b/floodmodeller_api/ief.py
@@ -185,7 +185,7 @@ class IEF(FMFile):
                     if idx == event_index:
                         # we enter this block if we're ready to write the event data
                         title = re.sub(
-                            r"_<\d>",
+                            r"_<\d>$",
                             "",
                             key,
                         )  # scrub off any extra bits we've added as part of the make-unique bit of reading.

--- a/floodmodeller_api/test/test_data/multievent.ief
+++ b/floodmodeller_api/test/test_data/multievent.ief
@@ -1,0 +1,43 @@
+[ISIS Event Header]
+Title=Multievent Test IEF
+Datafile=network.dat
+Results=..\Somewhere
+[ISIS Event Details]
+RunType=Unsteady
+InitialConditions=..\initial_conditions.iic
+Start=0
+Finish=360
+InitialTimestep=10
+MinimumTimestep=10
+MaximumTimestep=10
+SaveInterval=900
+;Fluvial Inflow
+EventData=..\network.ied
+;Event Override
+EventData=..\event_override.ied
+;Spill Data
+EventData=..\spill1.ied
+;Spill Data
+EventData=..\spill2.ied
+;
+EventData=..\ied_01.IED
+;
+EventData=..\ied_02.IED
+;
+EventData=..\ied_03.IED
+Dflood=5
+Qtol=0.1
+Minitr=5
+Maxitr=19
+Theta=0.55
+Weight=0.1
+AdaptiveTimestep=1
+RefineBridgeSecProps=0
+SolveDHEqualsZeroAtStart=1
+RulesAtTimeZero=1
+RulesOnFirstIteration=0
+ResetTimesAfterPos=1
+UseFPSModularLimit=1
+LaunchDoublePrecisionVersion=1
+UseRemoteQ=1
+2DFLOW=1

--- a/floodmodeller_api/test/test_ief.py
+++ b/floodmodeller_api/test/test_ief.py
@@ -226,9 +226,8 @@ def test_adding_eventdata(multievent_ief, sample_eventdata, tmpdir):
     new_ief = IEF(new_path)
     assert new_ief.eventdata == sample_eventdata
 
-#TODO test for 'renaming' and event
 
-def test_renaming_eventdata(multievent_ief,tmpdir):
+def test_renaming_eventdata(multievent_ief, tmpdir):
     """Tests renaming an event, after it has been substituted for a temporary one."""
 
     multievent_ief.eventdata["New Title"] = multievent_ief.eventdata.pop("<1>")
@@ -238,12 +237,11 @@ def test_renaming_eventdata(multievent_ief,tmpdir):
     new_ief = IEF(new_path)
 
     assert new_ief.eventdata == {
-                "Fluvial Inflow": "..\\network.ied",
-                "Event Override": "..\\event_override.ied",
-                "Spill Data": "..\\spill1.ied",
-                "Spill Data<0>": "..\\spill2.ied",
-                "<0>": "..\\ied_01.IED",
-                "<1>": "..\\ied_03.IED",
-                "New Title": "..\\ied_02.IED",
-            }
-    
+        "Fluvial Inflow": "..\\network.ied",
+        "Event Override": "..\\event_override.ied",
+        "Spill Data": "..\\spill1.ied",
+        "Spill Data<0>": "..\\spill2.ied",
+        "<0>": "..\\ied_01.IED",
+        "<1>": "..\\ied_03.IED",
+        "New Title": "..\\ied_02.IED",
+    }

--- a/floodmodeller_api/test/test_ief.py
+++ b/floodmodeller_api/test/test_ief.py
@@ -206,10 +206,10 @@ def test_unique_events_retained(multievent_ief: IEF):
                 "Fluvial Inflow": "..\\network.ied",
                 "Event Override": "..\\event_override.ied",
                 "Spill Data": "..\\spill1.ied",
-                "Spill Data_<1>": "..\\spill2.ied",
-                "": "..\\ied_01.IED",
-                "_<1>": "..\\ied_02.IED",
-                "_<2>": "..\\ied_03.IED",
+                "Spill Data<0>": "..\\spill2.ied",
+                "<0>": "..\\ied_01.IED",
+                "<1>": "..\\ied_02.IED",
+                "<2>": "..\\ied_03.IED",
                 "Added Event": "../added.ied",
             }
         ),
@@ -225,3 +225,25 @@ def test_adding_eventdata(multievent_ief, sample_eventdata, tmpdir):
 
     new_ief = IEF(new_path)
     assert new_ief.eventdata == sample_eventdata
+
+#TODO test for 'renaming' and event
+
+def test_renaming_eventdata(multievent_ief,tmpdir):
+    """Tests renaming an event, after it has been substituted for a temporary one."""
+
+    multievent_ief.eventdata["New Title"] = multievent_ief.eventdata.pop("<1>")
+    new_path = Path(tmpdir) / "tmp.ief"
+    multievent_ief.save(new_path)
+
+    new_ief = IEF(new_path)
+
+    assert new_ief.eventdata == {
+                "Fluvial Inflow": "..\\network.ied",
+                "Event Override": "..\\event_override.ied",
+                "Spill Data": "..\\spill1.ied",
+                "Spill Data<0>": "..\\spill2.ied",
+                "<0>": "..\\ied_01.IED",
+                "<1>": "..\\ied_03.IED",
+                "New Title": "..\\ied_02.IED",
+            }
+    

--- a/floodmodeller_api/test/test_ief.py
+++ b/floodmodeller_api/test/test_ief.py
@@ -17,6 +17,9 @@ def ief_fp(test_workspace: Path) -> Path:
 def ief(ief_fp: Path) -> IEF:
     return IEF(ief_fp)
 
+@pytest.fixture()
+def multievent_ief(test_workspace: Path) -> IEF:
+    return IEF(test_workspace / "multievent.ief")
 
 @pytest.fixture()
 def exe_bin(tmpdir) -> Path:
@@ -40,6 +43,7 @@ def sleep():
 
 def test_ief_read_doesnt_change_data(test_workspace, tmpdir):
     """IEF: Check all '.ief' files in folder by reading the _write() output into a new IEF instance and checking it stays the same."""
+    # we use this instead of parameterise so it will just automatically test any ief in the test data.
     for ief_file in Path(test_workspace).glob("*.ief"):
         ief = IEF(ief_file)
         first_output = ief._write()
@@ -182,3 +186,7 @@ def test_datafile_path(test_workspace: Path):
     path = Path(ief.Datafile)
     assert path.stem == "UptonP8_Panels"
     assert path.parent == Path("../../networks")
+
+def test_unique_events_retained(multievent_ief: IEF):
+    event_dict = multievent_ief.eventdata
+    assert len(event_dict) == 7

--- a/floodmodeller_api/test/test_ief.py
+++ b/floodmodeller_api/test/test_ief.py
@@ -230,7 +230,11 @@ def test_adding_eventdata(multievent_ief, sample_eventdata, tmpdir):
 def test_renaming_eventdata(multievent_ief, tmpdir):
     """Tests renaming an event, after it has been substituted for a temporary one."""
 
-    multievent_ief.eventdata["New Title"] = multievent_ief.eventdata.pop("<1>")
+    mapping = {"<1>": "New Title"}
+
+    multievent_ief.eventdata = {
+        mapping.get(key, key): value for key, value in multievent_ief.eventdata.items()
+    }
     new_path = Path(tmpdir) / "tmp.ief"
     multievent_ief.save(new_path)
 
@@ -242,6 +246,6 @@ def test_renaming_eventdata(multievent_ief, tmpdir):
         "Spill Data": "..\\spill1.ied",
         "Spill Data<0>": "..\\spill2.ied",
         "<0>": "..\\ied_01.IED",
-        "<1>": "..\\ied_03.IED",
         "New Title": "..\\ied_02.IED",
+        "<1>": "..\\ied_03.IED",
     }


### PR DESCRIPTION
Solution to 191.

Following steps highlighted by @joe-pierce, the following actions have been undertaken:

1. Duplicate event titles (including blank event titles) are suffixed with '_<1>', '_<2>' etc, where the first instance is left unchanged.
2. Upon writing, these suffixes are removed (via regex pattern, `_<\d>$`)
3. Sample .ief has been added, which inherently is already tested to ensure that it is not overwritten (`test_ief_read_doesnt_change_data`). Additional tests have been added ontop of this to ensure that the eventdata is handled correctly. (test_ief.py: `test_adding_eventdata`, `test_unique_events_retained`)
4. ief.rst has had a warning added which documents this behaviour.


I still don't fully agree with the solution applied here, however the code that I had added reads event data first as a list of tuples
`[("title1","ied1.ied"),("title2","ied2.ied")]`, then converts this to the above format at the end of `_read()`. This would make changing the behaviour here easier in the future if we choose to, as its a cleaner solution that operates closer to the 0.4.0 version of the API. Alternatively, the `raw_eventdata` variable within `_read()` could be kept as a (private (?) ) attribute to ensure that this is retained.

Please check that the changes to the docs have been applied properly, as I'm not sure if the build needs to be done by myself in as an edit or as part of an automatically applied github action?
