### PR TITLE
fix: fix gxy data parsing in _get_unit_locations method

### DIFF
--- a/floodmodeller_api/dat.py
+++ b/floodmodeller_api/dat.py
@@ -533,7 +533,9 @@ class DAT(FMFile):
 
     def _get_unit_locations(self):
         # use gxy data to assign locations to units.
-        gxy_lines = self._gxy_data.splitlines()
+        # gxy files may contain blank lines between entries so strip before parsing
+        assert self._gxy_data is not None
+        gxy_lines = list(filter(None, self._gxy_data.splitlines()))
         line = 0
         gxy_dict = {}
         while True:
@@ -549,11 +551,13 @@ class DAT(FMFile):
             # key should match ._unique_name attributes
             gxy_dict[f"{header[0]}_{header[2]}"] = (x, y)
 
-            line += 4
+            # set stride to 3 to match stripped gxy pattern
+            line += 3
 
         for unit in self._all_units:
-            if unit.unit in ("COMMENT",):
-                break
+            if unit.unit == "COMMENT":
+                # comment units have no location data but should not halt iteration; continue
+                continue
 
             if unit.unique_name in gxy_dict:
                 unit.set_cached_location_from_gxy(gxy_dict.pop(unit.unique_name))

--- a/floodmodeller_api/dat.py
+++ b/floodmodeller_api/dat.py
@@ -538,7 +538,7 @@ class DAT(FMFile):
         gxy_lines = list(filter(None, self._gxy_data.splitlines()))
         line = 0
         gxy_dict = {}
-        while True:
+        while line < len(gxy_lines):
             header = gxy_lines[line][1:-1].split("_", 2)
 
             # header format for a unit is [TYPE_SUBTYPE_NAME], so simple check that our header is a unit is check split length is 3

--- a/floodmodeller_api/test/test_dat.py
+++ b/floodmodeller_api/test/test_dat.py
@@ -5,7 +5,15 @@ from unittest.mock import patch
 import pytest
 
 from floodmodeller_api import DAT
-from floodmodeller_api.units import JUNCTION, LATERAL, QTBDY, RESERVOIR, UNSUPPORTED
+from floodmodeller_api.units import (
+    JUNCTION,
+    LATERAL,
+    QTBDY,
+    RESERVOIR,
+    RIVER,
+    SPILL,
+    UNSUPPORTED,
+)
 from floodmodeller_api.util import FloodModellerAPIError
 
 from .util import id_from_path, parameterise_glob
@@ -618,3 +626,38 @@ def test_units_with_spaces(
     with pytest.warns(UserWarning, match="contains spaces"):
         dat_roundtrip = DAT(roundtrip_path)
     assert dat_roundtrip._write() == actual_dat
+
+
+def test_gxy_locations_assigned():
+    """
+    GXY coordinates should be assigned across all unit type patterns
+    Blank lines between GXY entries are intentional to cover the stride fix.
+    """
+
+    gxy_data = (
+        "[QTBDY__Goyt]\r\n"
+        "X=390812.3751467\r\n"
+        "Y=390264.566334449\r\n"
+        "\r\n"
+        "[SPILL__RES9-10]\r\n"
+        "X=383759.168084381\r\n"
+        "Y=391263.373665862\r\n"
+        "\r\n"
+        "[RIVER_SECTION_OFSWEET]\r\n"
+        "X=379994.763064794\r\n"
+        "Y=393595.446452357\r\n"
+        "\r\n"
+    )
+
+    dat = DAT()
+    dat._gxy_data = gxy_data
+    dat._all_units = [
+        QTBDY(name="Goyt"),
+        SPILL(name="RES9-10"),
+        RIVER(name="OFSWEET"),
+    ]
+    dat._get_unit_locations()
+
+    assert dat._all_units[0].location == (390812.3751467, 390264.566334449)
+    assert dat._all_units[1].location == (383759.168084381, 391263.373665862)
+    assert dat._all_units[2].location == (379994.763064794, 393595.446452357)


### PR DESCRIPTION
# Proposed Changes

## Fix GXY location parsing in `_get_unit_locations`

- Strip blank lines before parsing and set stride value to 3 (header + X + Y).
- Change `break` to `continue` to prevent `COMMENT` units halting location assignment for subsequent units.
- Change `while True` to `while line < len(gxy_lines)` to prevent the loop walking off the end of the list.

## Housekeeping

- Added `assert self._gxy_data is not None` to satisfy Pyright type checking. 
- Simplified single-item membership test to equality check to satisfy Ruff.